### PR TITLE
`utils.merge` was referenced while only `merge` itself was imported

### DIFF
--- a/recuperabit/fs/ntfs.py
+++ b/recuperabit/fs/ntfs.py
@@ -892,7 +892,7 @@ class NTFSScanner(DiskScanner):
                                     ' %s (fragmented MFT)', piece.mft_pos, part
                                 )
                                 # Merge the partitions
-                                utils.merge(part, piece)
+                                merge(part, piece)
                                 # Remove the fragment
                                 partitioned_files.pop(position)
                             else:


### PR DESCRIPTION
`merge` was directly imported from `utils`, but this part of the code references `utils.merge`, and the `utils` module itself was not imported.
I simply changed `utils.merge` into just `merge`, dropping the `utils` part and fixing the error.